### PR TITLE
Add Copyright notices + Characters folder

### DIFF
--- a/Characters/README.txt
+++ b/Characters/README.txt
@@ -1,0 +1,3 @@
+The reason the ETCFiles folder and Characters folder are either missing or empty is because both folders contained copyrighted material from other creators, the only reason they exist on steam is purely for playable music in game for admins, as Barotrauma does not have a command to play them externally, and a lua command mod for the such has not been created yet.
+
+**DO NOT ADD COPYRIGHTED MATERIAL TO THE GITHUB**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # PlanetoidStation13
 The github repository for PlanetoidStation13, a Space Station 13 themed Barotrauma mod / server.
 
+# Notice
+
+The reason the ETCFiles folder and Characters folder are either missing or empty is because both folders contained copyrighted material from other creators, the only reason they exist on steam is purely for playable music in game for admins, as Barotrauma does not have a command to play them externally, and a lua command mod for the such has not been created yet.
+
+**DO NOT ADD COPYRIGHTED MATERIAL TO THE GITHUB**
+
 # License
 PlanetoidStation13 uses the Creative Commons 3.0 BY-SA License.
 


### PR DESCRIPTION
The reason the ETCFiles folder and Characters folder are either missing or empty is because both folders contained copyrighted material from other creators, the only reason they exist on steam is purely for playable music in game for admins, as Barotrauma does not have a command to play them externally, and a lua command mod for the such has not been created yet.

**DO NOT ADD COPYRIGHTED MATERIAL TO THE GITHUB**